### PR TITLE
Add ozinger-irc specific feature

### DIFF
--- a/sample.toml
+++ b/sample.toml
@@ -5,6 +5,8 @@ realname = ""
 nickname = ""
 channel = ""
 ignores = []
+ozinger_token = ""
+ozinger_appslug = ""
 
 [discord]
 token = ""

--- a/sample.toml
+++ b/sample.toml
@@ -5,7 +5,9 @@ realname = ""
 nickname = ""
 channel = ""
 ignores = []
-ozinger = { token = "", appslug = "" }
+
+# [irc.ozinger]
+# authline = "id pw"
 
 [discord]
 token = ""

--- a/sample.toml
+++ b/sample.toml
@@ -5,8 +5,7 @@ realname = ""
 nickname = ""
 channel = ""
 ignores = []
-ozinger_token = ""
-ozinger_appslug = ""
+ozinger = { token = "", appslug = "" }
 
 [discord]
 token = ""

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,8 @@ pub struct IrcConfig {
     pub channel: String,
     #[serde(default)]
     pub ignores: Vec<String>,
+    pub ozinger_token: String,
+    pub ozinger_appslug: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,7 @@ use {failure::Fallible, serde::Deserialize, std::path::PathBuf};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct IrcOzingerConfig {
-    pub token: String,
-    pub appslug: String,
+    pub authline: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,12 @@
 use {failure::Fallible, serde::Deserialize, std::path::PathBuf};
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct IrcOzingerConfig {
+    pub token: String,
+    pub appslug: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct IrcConfig {
     pub url: String,
     pub username: String,
@@ -9,8 +15,7 @@ pub struct IrcConfig {
     pub channel: String,
     #[serde(default)]
     pub ignores: Vec<String>,
-    pub ozinger_token: String,
-    pub ozinger_appslug: String,
+    pub ozinger: Option<IrcOzingerConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        config::*,
-        webhook::{execute_webhook_ozinger, OzingerWebhookBody},
-    },
+    crate::config::*,
     async_std::task::spawn,
     futures::{channel::mpsc::UnboundedSender, prelude::*},
     serenity::{model::channel::Message, prelude::*},
@@ -44,7 +41,7 @@ impl EventHandler for DiscordHandler {
             let Context { http, cache, .. } = ctx;
             let name = guild_id
                 .and_then(|guild_id| author.nick_in(http, guild_id))
-                .unwrap_or_else(|| author.name);
+                .unwrap_or(author.name);
 
             for user in mentions {
                 content = content.replace(&format!("{}", user.id), &user.name);
@@ -66,26 +63,22 @@ impl EventHandler for DiscordHandler {
                 } else {
                     info!("DIS> <{}> {}", name, line);
 
-                    if let Some(ozinger) = self.irc_config.ozinger.clone() {
-                        let body = OzingerWebhookBody {
-                            token: ozinger.token,
-                            sender: name.to_string(),
-                            target: self.irc_config.channel.to_string(),
-                            message: line.to_string(),
-                        };
-                        spawn(async move {
-                            execute_webhook_ozinger(&body).await
-                        });
-                    } else {
-                        let mut writer = self.irc_writer.clone();
-                        let msg = format!("PRIVMSG {} :<{}> {}\n", self.irc_config.channel, name, line, );
-                        spawn(async move {
-                            writer
-                                .send(msg)
-                                .unwrap_or_else(|err| error!("mpsc send error: {}", err))
-                                .await
-                        });
-                    }
+                    let mut writer = self.irc_writer.clone();
+                    let msg = match self.irc_config.ozinger {
+                        Some(_) => format!("FAKEMSG {}＠d!{:x}@pbzweihander/discord-irc-rs {} :{}\n",
+                            name.replace("!", "ǃ").replace("@", "＠"), // U+0021 -> U+01C3, U+0040 -> U+FE6B
+                            author.id.0,
+                            self.irc_config.channel,
+                            line,
+                        ),
+                        None => format!("PRIVMSG {} :<{}> {}\n", self.irc_config.channel, name, line, ),
+                    };
+                    spawn(async move {
+                        writer
+                            .send(msg)
+                            .unwrap_or_else(|err| error!("mpsc send error: {}", err))
+                            .await
+                    });
                 }
             }
         } else {

--- a/src/irc.rs
+++ b/src/irc.rs
@@ -43,8 +43,8 @@ pub async fn handle_irc(
         }
         Code::Privmsg => {
             let content = &msg.args[1];
-            if let Some(Prefix::User(PrefixUser { nickname, .. })) = msg.prefix {
-                if config.ignores.contains(&nickname) {
+            if let Some(Prefix::User(PrefixUser { nickname, hostname, .. })) = msg.prefix {
+                if config.ignores.contains(&nickname) || hostname == format!("{}.apps.api.ozinger.org", config.ozinger_appslug) {
                     debug!("IRC| <{}(ignored)> {}", nickname, content);
                 } else {
                     info!("IRC> <{}> {}", nickname, content);

--- a/src/irc.rs
+++ b/src/irc.rs
@@ -44,9 +44,15 @@ pub async fn handle_irc(
         Code::Privmsg => {
             let content = &msg.args[1];
             if let Some(Prefix::User(PrefixUser { nickname, hostname, .. })) = msg.prefix {
-                if config.ignores.contains(&nickname) || hostname == format!("{}.apps.api.ozinger.org", config.ozinger_appslug) {
+                if config.ignores.contains(&nickname) {
                     debug!("IRC| <{}(ignored)> {}", nickname, content);
                 } else {
+                    if let Some(ozinger) = config.ozinger {
+                        if hostname == format!("{}.apps.api.ozinger.org", ozinger.appslug) {
+                            return Ok(());
+                        }
+                    }
+
                     info!("IRC> <{}> {}", nickname, content);
 
                     let body = WebhookBody {

--- a/src/irc.rs
+++ b/src/irc.rs
@@ -30,11 +30,17 @@ pub async fn handle_irc(
             debug!("IRC> PONG to {}", args);
         }
         Code::RplWelcome => {
+            if let Some(ozinger) = config.ozinger {
+                write_irc!(writer, "OPER {}\n", ozinger.authline);
+            }
             write_irc!(writer, "JOIN {}\n", config.channel);
 
             info!("IRC> Joinning to {}...", config.channel);
 
             return Ok(());
+        }
+        Code::RplYoureoper | Code::ErrNooperhost => {
+            info!("Operator authentication result: {}", msg.args[1]);
         }
         Code::Join => {
             if let Some(Prefix::User(PrefixUser { nickname, .. })) = msg.prefix {
@@ -43,16 +49,10 @@ pub async fn handle_irc(
         }
         Code::Privmsg => {
             let content = &msg.args[1];
-            if let Some(Prefix::User(PrefixUser { nickname, hostname, .. })) = msg.prefix {
+            if let Some(Prefix::User(PrefixUser { nickname, .. })) = msg.prefix {
                 if config.ignores.contains(&nickname) {
                     debug!("IRC| <{}(ignored)> {}", nickname, content);
                 } else {
-                    if let Some(ozinger) = config.ozinger {
-                        if hostname == format!("{}.apps.api.ozinger.org", ozinger.appslug) {
-                            return Ok(());
-                        }
-                    }
-
                     info!("IRC> <{}> {}", nickname, content);
 
                     let body = WebhookBody {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> Fallible<()> {
 
     let mut client = serenity::Client::new(
         &discord.token.clone(),
-        DiscordHandler::new(discord, irc.channel, irc_sender),
+        DiscordHandler::new(discord, irc, irc_sender),
     )?;
 
     client.start()?;

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -9,29 +9,8 @@ pub struct WebhookBody {
     pub username: String,
 }
 
-#[derive(Serialize)]
-pub struct OzingerWebhookBody {
-    pub token: String,
-    pub sender: String,
-    pub target: String,
-    pub message: String,
-}
-
 pub async fn execute_webhook(url: &str, body: &WebhookBody) -> Fallible<()> {
     let resp = surf::post(url)
-        .body_json(body)?
-        .await
-        .map_err(Error::from_boxed_compat)?;
-    let status = resp.status();
-    if !status.is_success() {
-        Err(err_msg(status.as_str().to_string()))
-    } else {
-        Ok(())
-    }
-}
-
-pub async fn execute_webhook_ozinger(body: &OzingerWebhookBody) -> Fallible<()> {
-    let resp = surf::post("http://api.ozinger.org/chat")
         .body_json(body)?
         .await
         .map_err(Error::from_boxed_compat)?;

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -9,8 +9,29 @@ pub struct WebhookBody {
     pub username: String,
 }
 
+#[derive(Serialize)]
+pub struct OzingerWebhookBody {
+    pub token: String,
+    pub sender: String,
+    pub target: String,
+    pub message: String,
+}
+
 pub async fn execute_webhook(url: &str, body: &WebhookBody) -> Fallible<()> {
     let resp = surf::post(url)
+        .body_json(body)?
+        .await
+        .map_err(Error::from_boxed_compat)?;
+    let status = resp.status();
+    if !status.is_success() {
+        Err(err_msg(status.as_str().to_string()))
+    } else {
+        Ok(())
+    }
+}
+
+pub async fn execute_webhook_ozinger(body: &OzingerWebhookBody) -> Fallible<()> {
+    let resp = surf::post("http://api.ozinger.org/chat")
         .body_json(body)?
         .await
         .map_err(Error::from_boxed_compat)?;


### PR DESCRIPTION
If a [irc.ozinger] section is provided in the configuration file, use ozinger irc network's own FAKEMSG protocol when sending a message so it can be seen as other user's one (other than bot's nickname itself).