### PR TITLE
New option: prevent_noti_by_nicknames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1501,6 +1502,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ serde = "1.0.124"
 tokio = { version = "1.3.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.25"
 tracing-subscriber = "0.2.17"
+unicode-segmentation = "1.8.0"
 
 [dependencies.libirc]
 package = "irc"

--- a/sample.toml
+++ b/sample.toml
@@ -27,6 +27,8 @@ channel = ""
 ignores = []
 ## Set true to bridge changes of IRC members.
 # bridge_member_changes = false
+## Set true to prevent bot from notifying people with nicknames.
+# prevent_noti_by_nicknames = false
 
 ## Special config for ozinger.org IRC network.
 # [irc.ozinger]

--- a/sample.toml
+++ b/sample.toml
@@ -27,7 +27,8 @@ channel = ""
 ignores = []
 ## Set true to bridge changes of IRC members.
 # bridge_member_changes = false
-## Set true to prevent bot from notifying people with nicknames.
+## By setting this option as `true`, you can keep the bot from notifying people with nicknames
+## by inserting zero width spaces (U+200B) into nicknames.
 # prevent_noti_by_nicknames = false
 
 ## Special config for ozinger.org IRC network.

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,10 @@ pub struct IrcConfig {
     pub ozinger: Option<IrcOzingerConfig>,
     #[serde(default)]
     pub bridge_member_changes: bool,
+    /// By setting this option as `true`, you can keep the bot from notifying people with nicknames
+    /// by inserting zero width spaces (U+200B) into nicknames.
+    #[serde(default)]
+    pub prevent_noti_by_nicknames: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,54 @@
+use unicode_segmentation::UnicodeSegmentation;
+
 pub fn normalize_irc_nickname(s: &str) -> String {
     s.replace("!", "ǃ") // U+0021 -> U+01C3
         .replace("@", "＠") // U+0040 -> U+FE6B
         .replace(" ", "_")
+}
+
+pub fn insert_zero_width_spaces_into_nickname(nick: &str) -> String {
+    let graphemes: Vec<_> = nick.grapheme_indices(true).map(|entry| entry.0).collect();
+    match graphemes.len() {
+        0 => String::new(),
+        1 => nick.to_string(),
+        2 => {
+            let mut s = String::with_capacity(nick.len() + "\u{200B}".len());
+
+            let a = graphemes[1];
+
+            s.push_str(&nick[..a]);
+            s.push_str("\u{200B}");
+            s.push_str(&nick[a..]);
+            s
+        }
+        count => {
+            let mut s = String::with_capacity(nick.len() + "\u{200B}".len() * 2);
+
+            let a = graphemes[count / 3];
+            let b = graphemes[count * 2 / 3];
+
+            s.push_str(&nick[..a]);
+            s.push_str("\u{200B}");
+            s.push_str(&nick[a..b]);
+            s.push_str("\u{200B}");
+            s.push_str(&nick[b..]);
+            s
+        }
+    }
+}
+
+#[test]
+pub fn test_insert_boms_into_nickname() {
+    let f = insert_zero_width_spaces_into_nickname;
+
+    assert_eq!(f("기이다란닉네임"), "기이\u{200B}다란\u{200B}닉네임");
+    assert_eq!(f("기다란닉네임"), "기다\u{200B}란닉\u{200B}네임");
+    assert_eq!(f("가나다라마"), "가\u{200B}나다\u{200B}라마");
+    assert_eq!(f("지현지현"), "지\u{200B}현\u{200B}지현");
+    assert_eq!(f("김지현"), "김\u{200B}지\u{200B}현");
+    assert_eq!(f("지현"), "지\u{200B}현");
+    assert_eq!(f("젼"), "젼");
+    assert_eq!(f(""), "");
+
+    assert_eq!(f("a̐éö̲"), "a̐\u{200B}é\u{200B}ö̲");
 }


### PR DESCRIPTION
When the 'prevent_noti_by_nicknames' option is turned on, up to two zero width spaces (U+200B) are inserted into the nickname so that IRC users do not receive undesired notifications.

Tested with irssi 1.2.3, weechat 3.3, and weechat 2.8 with ZNC.