### PR TITLE
New option: auto_detect_avatar

### DIFF
--- a/sample.toml
+++ b/sample.toml
@@ -30,6 +30,10 @@ ignores = []
 ## By setting this option as `true`, you can keep the bot from notifying people with nicknames
 ## by inserting zero width spaces (U+200B) into nicknames.
 # prevent_noti_by_nicknames = false
+## Set true to automatically detect the avater of IRC users.
+##
+## NOTE: This option requires "Server Members Intent", and "Presence Intent".
+# auto_detect_avatar = false
 
 ## Special config for ozinger.org IRC network.
 # [irc.ozinger]
@@ -40,6 +44,9 @@ ignores = []
 ## "Application ID" of Discord application. Please refer to the following links
 ## on how to create an application (a.k.a. bot account) and retrieve a token
 ## from it:
+##
+## NOTE: This bot always requires "Message Content Intent".
+##
 ## - https://discord.com/developers/docs/topics/oauth2#bots
 ## - https://discord.com/developers/applications
 token = ""

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,10 @@ pub struct IrcConfig {
     /// by inserting zero width spaces (U+200B) into nicknames.
     #[serde(default)]
     pub prevent_noti_by_nicknames: bool,
+    /// By setting this option as `true`, this bot will automatically detect the avatar of IRC
+    /// users by searching for the user with the same nickname on the Discord channel.
+    #[serde(default)]
+    pub auto_detect_avatar: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use libirc::client::Client;
 
 async fn irc_handler_future(
     mut irc_client: Client,
-    discord_http: Arc<serenity::http::client::Http>,
+    discord_http: Arc<serenity::CacheAndHttp>,
     irc_config: config::IrcConfig,
     discord_config: config::DiscordConfig,
 ) -> Result<()> {
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
 
     let irc_fut = irc_handler_future(
         irc_client,
-        discord_client.cache_and_http.http.clone(),
+        discord_client.cache_and_http.clone(),
         irc_config,
         discord_config,
     );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,7 @@ pub fn insert_zero_width_spaces_into_nickname(nick: &str) -> String {
             let a = graphemes[1];
 
             s.push_str(&nick[..a]);
-            s.push_str("\u{200B}");
+            s.push('\u{200B}');
             s.push_str(&nick[a..]);
             s
         }
@@ -28,9 +28,9 @@ pub fn insert_zero_width_spaces_into_nickname(nick: &str) -> String {
             let b = graphemes[count * 2 / 3];
 
             s.push_str(&nick[..a]);
-            s.push_str("\u{200B}");
+            s.push('\u{200B}');
             s.push_str(&nick[a..b]);
-            s.push_str("\u{200B}");
+            s.push('\u{200B}');
             s.push_str(&nick[b..]);
             s
         }


### PR DESCRIPTION
When the 'auto_detect_avatar' option is turned on, this bot automatically detects an avatar of IRC user using the avatar of the Discord user with a same nickname.

with 'auto_detect_avatar' off: (existing behavior, default)
![image](https://user-images.githubusercontent.com/4435445/142738985-a60b4157-19e8-4572-9c56-792ec699151b.png)

with 'auto_detect_avatar' on:
![image](https://user-images.githubusercontent.com/4435445/142739002-b4e5fd89-2f3c-4d5d-8ff5-960304901a22.png)
