### PR TITLE
Ignore HTTP URLs while formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,12 +199,15 @@ dependencies = [
  "config",
  "futures",
  "irc",
+ "once_cell",
+ "regex",
  "serde 1.0.130",
  "serenity",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "unicode-segmentation",
+ "url",
 ]
 
 [[package]]
@@ -803,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,14 @@ edition = "2018"
 anyhow = "1.0.38"
 futures = "0.3.13"
 libconfig = { version = "0.11.0", package = "config" }
+once_cell = "1.9.0"
+regex = { version = "1.5.4", default-features = false, features = ["std", "perf"] }
 serde = "1.0.124"
 tokio = { version = "1.3.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.25"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 unicode-segmentation = "1.8.0"
+url = "2.2.2"
 
 [dependencies.libirc]
 package = "irc"


### PR DESCRIPTION
URL이라고 생각되는 부분 문자열을 정규식으로 찾아낸 뒤 파싱을 시도해 정말로 URL이 맞는지 확인합니다.
만약 맞다면 해당 부분은 이스케이프 처리에서 제외합니다.

URL에 `_` 등의 문자가 포함된 경우 이스케이프 처리로 인해 URL이 제대로 전달되지 않는 현상을
수정합니다.
